### PR TITLE
Add turbolinks:load for turbolinks compatability.

### DIFF
--- a/vendor/assets/javascripts/progressive_render.js.coffee
+++ b/vendor/assets/javascripts/progressive_render.js.coffee
@@ -18,3 +18,5 @@ load_missing_content = ->
     $.ajax url: $this.data('progressive-render-path'), cache: false, success: (response) -> 
       $this.html(response); 
       $(document).trigger('progressive_render:end')
+      
+  $(document).on 'turbolinks:load', load_missing_content if window.Turbolinks


### PR DESCRIPTION
By adding this, progressive render will continue to work as expected between page loads from turbolinks.